### PR TITLE
 FIX for #5 to facilitate validation on SiteConfig via DataExtension's.

### DIFF
--- a/templates/Includes/SiteConfigLeftAndMain_Content.ss
+++ b/templates/Includes/SiteConfigLeftAndMain_Content.ss
@@ -1,4 +1,4 @@
-<div id="settings-controller-cms-content" class="cms-content center cms-tabset $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content CurrentForm" data-ignore-tab-state="true">
+<div id="settings-controller-cms-content" class="cms-content center cms-tabset $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content" data-ignore-tab-state="true">
 
 	<div class="cms-content-header north">
 		<% with $EditForm %>


### PR DESCRIPTION
Fix for issue #5. 

**NOTE:** I'm aware that validation on a separate/new tab doesn't bring focus to the correct tab. I'm working on that. I personally think that should be addressed as a separate issue (likely here, since now `SiteConfig` should be abstracted and self-contained). Currently this is controlled via [LeftAndMain.EditForm.js](https://github.com/silverstripe/silverstripe-framework/blob/3.2/admin/javascript/LeftAndMain.EditForm.js#L88). 