### PR TITLE
Fixed breadcrumbs being broken when using GridField on 'SiteConfig'

### DIFF
--- a/code/controller/SiteConfigLeftAndMain.php
+++ b/code/controller/SiteConfigLeftAndMain.php
@@ -122,7 +122,7 @@ class SiteConfigLeftAndMain extends LeftAndMain {
 		return new ArrayList(array(
 			new ArrayData(array(
 				'Title' => _t("{$this->class}.MENUTITLE", $defaultTitle),
-				'Link' => false
+				'Link' => $this->Link()
 			))
 		));
 	}


### PR DESCRIPTION
This solved the issue where SiteConfig breadcrumbs are broken when editing in a GridField. I'm not sure why the breadcrumbs link is 'false' in the first place.

It should be noted that I use Unclecheese's Betterbuttons, so I can't be 100% sure if that isn't causing problems too, but breadcrumbs work fine in 3.1.