### PR TITLE
Swap out .Actions class for bootstrap .btn-toolbar

### DIFF
--- a/templates/Includes/SiteConfigLeftAndMain_EditForm.ss
+++ b/templates/Includes/SiteConfigLeftAndMain_EditForm.ss
@@ -16,9 +16,9 @@
 		</fieldset>
 	</div>
 
-	<div class="cms-content-actions cms-content-controls south">
+	<div class="toolbar--south cms-content-actions cms-content-controls south">
 		<% if $Actions %>
-		<div class="Actions">
+		 <div class="btn-toolbar">
 			<% loop $Actions %>
 				$Field
 			<% end_loop %>


### PR DESCRIPTION
So siteconfig can be saved after https://github.com/silverstripe/silverstripe-framework/commit/f4037fe31968409d6c0ea6095a82a37f10067ae2