### PR TITLE
Remove JLayout legacy classes

### DIFF
--- a/code/SiteConfigLeftAndMain.php
+++ b/code/SiteConfigLeftAndMain.php
@@ -91,7 +91,7 @@ class SiteConfigLeftAndMain extends LeftAndMain
 				));
 			}
 		});
-		$form->addExtraClass('cms-content center cms-edit-form fill-height flexbox-area-grow');
+		$form->addExtraClass('flexbox-area-grow fill-height cms-content cms-edit-form');
 		$form->setAttribute('data-pjax-fragment', 'CurrentForm');
 
         if ($form->Fields()->hasTabSet()) {

--- a/templates/SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_Content.ss
+++ b/templates/SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_Content.ss
@@ -1,4 +1,4 @@
-<div id="settings-controller-cms-content" class="cms-content flexbox-area-grow fill-height center cms-tabset $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content" data-ignore-tab-state="true">
+<div id="settings-controller-cms-content" class="flexbox-area-grow fill-height cms-content cms-tabset $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content" data-ignore-tab-state="true">
 
 	<div class="cms-content-header north">
 		<% with $EditForm %>

--- a/templates/SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_EditForm.ss
+++ b/templates/SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_EditForm.ss
@@ -1,6 +1,6 @@
 <form $FormAttributes data-layout-type="border">
 
-	<div class="panel panel--padded panel--scrollable flexbox-area-grow cms-content-fields ">
+	<div class="panel panel--padded panel--scrollable flexbox-area-grow cms-content-fields">
 		<% if $Message %>
 		<p id="{$FormName}_error" class="message $MessageType">$Message</p>
 		<% else %>
@@ -16,7 +16,7 @@
 		</fieldset>
 	</div>
 
-	<div class="toolbar toolbar--south cms-content-actions cms-content-controls south">
+	<div class="toolbar toolbar--south cms-content-actions cms-content-controls">
 		<% if $Actions %>
 		 <div class="btn-toolbar">
 			<% loop $Actions %>


### PR DESCRIPTION
Removed legacy classes "north, south etc" which JLayout used before it was removed.

Can be merged with Framework, CMS, AssetAdmin, Site-config branches of features/4.0/responsive-improvements see https://github.com/silverstripe/silverstripe-framework/issues/6164

This work can also be merged independently of the other branches mentioned above as there shouldn't be any dependencies. 