### PR TITLE
FIX Remove legacy translation behaviour in template

### DIFF
--- a/templates/SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_EditForm.ss
+++ b/templates/SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_EditForm.ss
@@ -24,7 +24,7 @@
 			<% end_loop %>
 			<% if $Controller.LinkPreview %>
 				<a href="$Controller.LinkPreview" class="cms-preview-toggle-link ss-ui-button" data-icon="preview">
-					<% _t('SilverStripe\Admin\LeftAndMain.PreviewButton', 'Preview') %> &raquo;
+					<%t SilverStripe\Admin\LeftAndMain.PreviewButton 'Preview' %> &raquo;
 				</a>
 			<% end_if %>
 		</div>

--- a/templates/SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_EditForm.ss
+++ b/templates/SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_EditForm.ss
@@ -24,7 +24,7 @@
 			<% end_loop %>
 			<% if $Controller.LinkPreview %>
 				<a href="$Controller.LinkPreview" class="cms-preview-toggle-link ss-ui-button" data-icon="preview">
-					<%t SilverStripe\Admin\LeftAndMain.PreviewButton 'Preview' %> &raquo;
+					<%t SilverStripe\\Admin\\LeftAndMain.PreviewButton 'Preview' %> &raquo;
 				</a>
 			<% end_if %>
 		</div>


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/6582

This is a template syntax change only, no translation changes.