### PR TITLE
FIX Update translation default from "only these people" to "only these groups" to match CMS

### DIFF
--- a/code/SiteConfig.php
+++ b/code/SiteConfig.php
@@ -136,7 +136,7 @@ class SiteConfig extends DataObject implements PermissionProvider, TemplateGloba
         $viewersOptionsSource = array();
         $viewersOptionsSource["Anyone"] = _t('SilverStripe\\CMS\\Model\\SiteTree.ACCESSANYONE', "Anyone");
         $viewersOptionsSource["LoggedInUsers"] = _t('SilverStripe\\CMS\\Model\\SiteTree.ACCESSLOGGEDIN', "Logged-in users");
-        $viewersOptionsSource["OnlyTheseUsers"] = _t('SilverStripe\\CMS\\Model\\SiteTree.ACCESSONLYTHESE', "Only these people (choose from list)");
+        $viewersOptionsSource["OnlyTheseUsers"] = _t('SilverStripe\\CMS\\Model\\SiteTree.ACCESSONLYTHESE', "Only these groups (choose from list)");
         $viewersOptionsField->setSource($viewersOptionsSource);
 
         if ($viewAllGroupsMap) {


### PR DESCRIPTION
This was changed in the CMS with https://github.com/silverstripe/silverstripe-cms/pull/1880, updating the default here (doesn't get used in the current 4.0.x-dev anyway).