### PR TITLE
FIX create_default_pages = false still created default siteconfig

### DIFF
--- a/code/SiteConfig.php
+++ b/code/SiteConfig.php
@@ -253,7 +253,7 @@ class SiteConfig extends DataObject implements PermissionProvider, TemplateGloba
 
         $config = DataObject::get_one(SiteConfig::class);
 
-        if (!$config) {
+        if (!$config && $this->config()->create_default_pages) {
             self::make_site_config();
 
             DB::alteration_message("Added default site config", "created");


### PR DESCRIPTION
If we're not creating default pages, don't create default siteconfig either.