### PR TITLE
Expose as vendor module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ matrix:
 
 before_script:
 # Init PHP
-  - export CORE_RELEASE=$TRAVIS_BRANCH
   - phpenv rehash
   - phpenv config-rm xdebug.ini || true
 
@@ -45,7 +44,7 @@ before_script:
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
-  - composer require symfony/config:^3.2 silverstripe/framework:4.0.x-dev silverstripe/cms:4.0.x-dev silverstripe/siteconfig:4.0.x-dev silverstripe/config:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/versioned:1.0.x-dev silverstripe-themes/simple:~3.2.0 --no-update
+  - composer require --no-update silverstripe/installer:4.0.x-dev
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - COMPOSER_ROOT_VERSION="4.0.x-dev"
     - DISPLAY=":99"
     - XVFBARGS=":99 -ac -screen 0 1024x768x16"
+    - SS_BASE_URL="http://localhost:8080/"
+    - SS_ENVIRONMENT_TYPE="dev"
 
 matrix:
   fast_finish: true
@@ -47,16 +49,12 @@ before_script:
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
-# Bootstrap cms / mysite folder
-  - php ./tests/bootstrap/mysite.php
-
 # Behat bootstrapping
-  - if [[ $BEHAT_TEST ]]; then echo "" >> .env && echo "SS_BASE_URL=http://localhost:8080/" >> .env; fi
   - if [[ $BEHAT_TEST ]]; then mkdir artifacts; fi
   - if [[ $BEHAT_TEST ]]; then cp composer.lock artifacts/; fi
   - if [[ $BEHAT_TEST ]]; then sh -e /etc/init.d/xvfb start; sleep 3; fi
   - if [[ $BEHAT_TEST ]]; then (vendor/bin/selenium-server-standalone > artifacts/selenium.log 2>&1 &); fi
-  - if [[ $BEHAT_TEST ]]; then (vendor/bin/serve --bootstrap-file cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
+  - if [[ $BEHAT_TEST ]]; then (vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/php; fi
@@ -68,4 +66,4 @@ after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi
 
 after_failure:
-  - if [[ $BEHAT_TEST ]]; then php ./framework/tests/behat/travis-upload-artifacts.php --if-env BEHAT_TEST,ARTIFACTS_BUCKET,ARTIFACTS_KEY,ARTIFACTS_SECRET --target-path $TRAVIS_REPO_SLUG/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID --artifacts-base-url https://s3.amazonaws.com/$ARTIFACTS_BUCKET/ --artifacts-path ./artifacts/; fi
+  - if [[ $BEHAT_TEST ]]; then php ./vendor/silverstripe/framework/tests/behat/travis-upload-artifacts.php --if-env BEHAT_TEST,ARTIFACTS_BUCKET,ARTIFACTS_KEY,ARTIFACTS_SECRET --target-path $TRAVIS_REPO_SLUG/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID --artifacts-base-url https://s3.amazonaws.com/$ARTIFACTS_BUCKET/ --artifacts-path ./artifacts/; fi

--- a/behat.yml
+++ b/behat.yml
@@ -24,4 +24,4 @@ default:
 
     SilverStripe\BehatExtension\Extension:
       screenshot_path: %paths.base%/artifacts/screenshots
-      bootstrap_file: "cms/tests/behat/serve-bootstrap.php"
+      bootstrap_file: "vendor/silverstripe/cms/tests/behat/serve-bootstrap.php"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "silverstripe/siteconfig",
     "description": "Site wide settings administration.",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "keywords": [
         "silverstripe",
         "siteconfig"
@@ -14,7 +14,8 @@
     ],
     "require": {
         "silverstripe/framework": "^4.0@dev",
-        "silverstripe/admin": "^1.0@dev"
+        "silverstripe/admin": "^1.0@dev",
+        "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
 
 	<testsuite name="Default">
 		<directory>tests</directory>


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405
Merge after https://github.com/silverstripe/silverstripe-framework/pull/7395

Manually tested by opening and saving `admin/settings`

Test (after merging the framework pull request):

```
composer config repositories.siteconfig vcs https://github.com/open-sausages/silverstripe-siteconfig.git
composer require "silverstripe/siteconfig:dev-pulls/4/vendorise-me-baby as 4.0.x-dev"
```