### PR TITLE
Only require `CMSMain.EditForm` if `CMS_DIR` is defined

### DIFF
--- a/code/controller/SiteConfigLeftAndMain.php
+++ b/code/controller/SiteConfigLeftAndMain.php
@@ -40,7 +40,9 @@ class SiteConfigLeftAndMain extends LeftAndMain {
 	 */
 	public function init() {
 		parent::init();
-		Requirements::javascript(CMS_DIR . '/javascript/CMSMain.EditForm.js');
+		if (defined('CMS_DIR')) {
+			Requirements::javascript(CMS_DIR . '/javascript/CMSMain.EditForm.js');
+		}
 	}
 
 	/**
@@ -69,7 +71,7 @@ class SiteConfigLeftAndMain extends LeftAndMain {
 		}
 
 		$actions = $siteConfig->getCMSActions();
-		$form = CMSForm::create( 
+		$form = CMSForm::create(
 			$this, 'EditForm', $fields, $actions, $validator
 		)->setHTMLID('Form_EditForm');
 		$form->setResponseNegotiator($this->getResponseNegotiator());
@@ -102,26 +104,26 @@ class SiteConfigLeftAndMain extends LeftAndMain {
 	/**
 	 * Save the current sites {@link SiteConfig} into the database.
 	 *
-	 * @param array $data 
-	 * @param Form $form 
+	 * @param array $data
+	 * @param Form $form
 	 * @return String
 	 */
 	public function save_siteconfig($data, $form) {
 		$siteConfig = SiteConfig::current_site_config();
 		$form->saveInto($siteConfig);
-		
+
 		try {
 			$siteConfig->write();
 		} catch(ValidationException $ex) {
 			$form->sessionMessage($ex->getResult()->message(), 'bad');
 			return $this->getResponseNegotiator()->respond($this->request);
 		}
-		
+
 		$this->response->addHeader('X-Status', rawurlencode(_t('LeftAndMain.SAVEDUP', 'Saved.')));
 
 		return $form->forTemplate();
 	}
-	
+
 
 	public function Breadcrumbs($unlinked = false) {
 		$defaultTitle = self::menu_title_for_class(get_class($this));


### PR DESCRIPTION
Same fix as https://github.com/silverstripe/silverstripe-siteconfig/pull/45/files for the 3.6 line. Plus whitespace fixes 