### PR TITLE
NEW Use Bootstrap alerts instead of legacy message classes for install.php warning

### DIFF
--- a/code/SiteConfig.php
+++ b/code/SiteConfig.php
@@ -209,15 +209,15 @@ class SiteConfig extends DataObject implements PermissionProvider, TemplateGloba
 
         if (file_exists(BASE_PATH . '/install.php')) {
             $fields->addFieldToTab(
-                "Root.Main",
-                new LiteralField(
-                    "InstallWarningHeader",
-                    "<p class=\"message warning\">" . _t(
-                        SiteTree::class . 'REMOVE_INSTALL_WARNING',
+                'Root.Main',
+                LiteralField::create(
+                    'InstallWarningHeader',
+                    '<div class="alert alert-warning">' . _t(
+                        'SilverStripe\\CMS\\Model\\SiteTree.REMOVE_INSTALL_WARNING',
                         'Warning: You should remove install.php from this SilverStripe install for security reasons.'
-                    ) . "</p>"
+                    ) . '</div>'
                 ),
-                "Title"
+                'Title'
             );
         }
 


### PR DESCRIPTION
Related issue: https://github.com/silverstripe/silverstripe-admin/issues/201

cc @sachajudd

CMS pull request: https://github.com/silverstripe/silverstripe-cms/pull/2085

Before:

![image](https://user-images.githubusercontent.com/5170590/35710011-14905252-081a-11e8-8752-953f4a63b3d2.png)

After:

![image](https://user-images.githubusercontent.com/5170590/35710038-1fb3e28e-081a-11e8-9b7e-c3959b8e7c8d.png)
