### PR TITLE
Add an extension point to customise/override returned current site config

### DIFF
--- a/code/SiteConfig.php
+++ b/code/SiteConfig.php
@@ -271,11 +271,13 @@ class SiteConfig extends DataObject implements PermissionProvider, TemplateGloba
     {
         /** @var SiteConfig $siteConfig */
         $siteConfig = DataObject::get_one(SiteConfig::class);
-        if ($siteConfig) {
-            return $siteConfig;
+        if (!$siteConfig) {
+            $siteConfig = self::make_site_config();
         }
 
-        return self::make_site_config();
+        static::singleton()->extend('updateCurrentSiteConfig', $siteConfig);
+
+        return $siteConfig;
     }
 
     /**


### PR DESCRIPTION
The extension point is useful when working e.g. with Subsites in a way where access to both the subsite's and the global site config is required in various places under the same subsite/main site.