### PR TITLE
FIX Do not cache current site config

### DIFF
--- a/code/SiteConfig.php
+++ b/code/SiteConfig.php
@@ -339,7 +339,7 @@ class SiteConfig extends DataObject implements PermissionProvider, TemplateGloba
      */
     public static function current_site_config()
     {
-        $siteConfig = DataObject::get_one(SiteConfig::class);
+        $siteConfig = DataObject::get_one(SiteConfig::class, null, false);
         if (!$siteConfig) {
             $siteConfig = self::make_site_config();
         }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/272

When running behat on siteconfig from a recipe-kitchen-sink context only, the following behat tests will fail
- vendor/silverstripe/siteconfig/tests/behat/features/manage-page-permissions.feature:87
- vendor/silverstripe/siteconfig/tests/behat/features/manage-page-permissions.feature:95

The fail because $this->CanEditType in SiteConfig::canEditPages() will incorrectly by 'LoggedInUsers' instead of 'OnlyTheseUsers' - not this is NOT run-over from another behat tests, it happens when the tests are run individually

Beucase SiteConfig::current_site_config() is used at some point, and it will use a cached version of SiteConfig::get_one(), which is getting set at some point in recipe-kitchen-sink (I wasn't able to work out exactly where) which it normally isn't during installer.

I've had a look to see if SiteConfig::current_site_config() is being used in loops anywhere and it isn't, so the performance loss on not using the cache should be basically irrelevant


