### PR TITLE
DEP Don't include vendor-plugin as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/framework": "^6",
-        "silverstripe/admin": "^3",
-        "silverstripe/vendor-plugin": "^2"
+        "silverstripe/admin": "^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3",


### PR DESCRIPTION
We don't directly reference it in code or config, so we can rely on silverstripe/framework having this dependency for us.

## Issue
- https://github.com/silverstripe/.github/issues/311