### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/code/SiteConfig.php
+++ b/code/SiteConfig.php
@@ -288,7 +288,7 @@ class SiteConfig extends DataObject implements PermissionProvider, TemplateGloba
      */
     public static function current_site_config(): SiteConfig
     {
-        $siteConfig = DataObject::get_one(SiteConfig::class);
+        $siteConfig = SiteConfig::get()->setUseCache(true)->first();
         if (!$siteConfig) {
             $siteConfig = SiteConfig::make_site_config();
         }
@@ -302,7 +302,7 @@ class SiteConfig extends DataObject implements PermissionProvider, TemplateGloba
     {
         parent::requireDefaultRecords();
 
-        $config = DataObject::get_one(SiteConfig::class);
+        $config = SiteConfig::get()->setUseCache(true)->first();
 
         if (!$config) {
             SiteConfig::make_site_config();

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/admin": "^3"
     },
     "require-dev": {


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
