### PR TITLE
API Set config to skip permission generation

### DIFF
--- a/code/SiteConfigLeftAndMain.php
+++ b/code/SiteConfigLeftAndMain.php
@@ -22,6 +22,8 @@ class SiteConfigLeftAndMain extends SingleRecordAdmin
         'EDIT_SITECONFIG',
     ];
 
+    private static bool $skip_permission_generation = true;
+
     public function init()
     {
         parent::init();


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/2107

- Add skip_permission_generation config for SiteConfigLeftAndMain
